### PR TITLE
Add FOSS Governance and OpenSourceConduct sites

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,3 +1,4 @@
 * Daniel S. Katz, [@danielskatz](http://github.com/danielskatz), http://orcid.org/0000-0001-5934-7525
 * Megan Forbes, [@meganforbes](http://github.com/meganforbes), https://orcid.org/0000-0002-2611-1441
 * Leah Silen, [@lsilen](http://github.com/lsilen)
+* Shane Curcuru, [@shanecurcuru)](https://github.com/ShaneCurcuru/), https://orcid.org/0000-0002-7530-3108

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository is intended to collect guidance, documents, examples, templates 
 * [Minimum Viable Governance](https://github.com/github/MVG)
 * [Goverining Open](https://governingopen.com)
 * [CommunityRule](https://communityrule.info/)
+* [FOSS Governance](https://fossgovernance.org/) and underlying [Zotero governance library](https://www.zotero.org/groups/2310183/foss_governance/library)
 * [CSCCE's November 2021 community call recap: Exploring community governance models](https://www.cscce.org/2021/11/19/novembers-community-call-recap-exploring-community-governance-models/)
 * Examples
   * napari: https://napari.org/stable/community/governance.html
@@ -29,6 +30,7 @@ This repository is intended to collect guidance, documents, examples, templates 
 * [Open Seed's Designing and enforcing a Code of Conduct by Saskia Freytag](https://docs.google.com/presentation/d/1E0HBEzzuO3VjNLwM3ThWLJ27R6h359j0DO4jwfcFkCw/edit)
 * [Open Source Guide's Your Code of Conduct](https://opensource.guide/code-of-conduct/)
 * [rOpenSci's 2016 Highlights and Resources from Community Call v12: How do I create a code of conduct for my event/lab/codebase?](https://ropensci.org/blog/2016/12/21/commcallv12-review-coc/)
+* [Open Source Project Codes of Conduct](https://opensourceconduct.com/)
 * Examples
   * Contributor Convenant: https://www.contributor-covenant.org
   * NumFOCUS: https://numfocus.org/code-of-conduct


### PR DESCRIPTION
Two useful overview sites for specific governance documents of current FOSS Foundations, and a solid overview of COCs commonly used.
Thanks! 