### PR TITLE
Suggested edits

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,3 +4,4 @@
 * Shane Curcuru, [@shanecurcuru](https://github.com/ShaneCurcuru/), https://orcid.org/0000-0002-7530-3108
 * Michael Hucka, [@mhucka](https://github.com/mhucka), https://orcid.org/0000-0001-9105-5960
 * Yuan Tang, [@terrytangyuan](http://github.com/terrytangyuan), https://orcid.org/0000-0001-5243-233X
+* Bill Branan, [@bbranan](https://github.com/bbranan), https://orcid.org/0000-0002-4735-6624

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository is intended to collect guidance, documents, examples, templates 
 * [Participating in Open Source Communities](https://www.linuxfoundation.org/resources/open-source-guides/participating-in-open-source-communities)
 * [OpenSSF Best Practices Badge Program](https://www.bestpractices.dev/en)
 * [Code for Science and Society's Digital Infrastructure Incubator resources](https://www.codeforsociety.org/incubator/resources/dii-resource)
+* [Mozilla's Open Leadership Training Series's Best Practices in Working Open](https://web.archive.org/web/20241028115543/https://mozilla.github.io/open-leadership-training-series/)
 * [It Takes a Village: OS Sustainability for Cultural and Scientific Heritage](https://itav.lyrasis.org)
 * [Program Management for Open Source Projects](https://pragprog.com/titles/bcosp/program-management-for-open-source-projects/)
 * [The Turing Way](https://book.the-turing-way.org/index.html)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository is intended to collect guidance, documents, examples, templates 
 * [Code for Science and Society's Digital Infrastructure Incubator resources](https://www.codeforsociety.org/incubator/resources/dii-resource)
 * [It Takes a Village: OS Sustainability for Cultural and Scientific Heritage](https://itav.lyrasis.org)
 * [Program Management for Open Source Projects](https://pragprog.com/titles/bcosp/program-management-for-open-source-projects/)
+* [The Turing Way](https://book.the-turing-way.org/index.html)
+* [Open Source Explainers](https://ospo.library.jhu.edu/learn-grow/ospo-explainers/)
 
 ### Governance
 
@@ -23,6 +25,7 @@ This repository is intended to collect guidance, documents, examples, templates 
 * [CSCCE's November 2021 community call recap: Exploring community governance models](https://www.cscce.org/2021/11/19/novembers-community-call-recap-exploring-community-governance-models/)
 * [Building Leadership in an Open Source Community](https://www.linuxfoundation.org/resources/open-source-guides/building-leadership-in-an-open-source-community)
 * [SustainOSS's Governance Readiness Checklist](https://sustainers.github.io/governance-readiness/)
+* [The Good Governance Initiative](https://ospo-alliance.org/ggi/introduction/)
 * Examples
   * napari: https://napari.org/stable/community/governance.html
   * NumPy: https://numpy.org/doc/stable/dev/governance/governance.html

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This repository is intended to collect guidance, documents, examples, templates 
 * [Participating in Open Source Communities](https://www.linuxfoundation.org/resources/open-source-guides/participating-in-open-source-communities)
 * [OpenSSF Best Practices Badge Program](https://www.bestpractices.dev/en)
 * [Code for Science and Society's Digital Infrastructure Incubator resources](https://www.codeforsociety.org/incubator/resources/dii-resource)
-* [Mozilla's Open Leadership Training Series's Best Practices in Working Open](https://mozilla.github.io/open-leadership-training-series/)
 * [It Takes a Village: OS Sustainability for Cultural and Scientific Heritage](https://itav.lyrasis.org)
 * [Program Management for Open Source Projects](https://pragprog.com/titles/bcosp/program-management-for-open-source-projects/)
 


### PR DESCRIPTION
This removes the Mozilla Open Leadership link as it now returns a 404. The GitHub Pages site appears to have been taken down and the repository archived. I also added a few other resources while I was at it.